### PR TITLE
automatic initialization

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,10 +1,19 @@
     var $div = document.querySelector('#pointer');
     var $console = document.querySelector('#console');
-    var pointer = new PointerTracker($div);
+    var EVENTS = {
+		up: 'pointerup',
+		down: 'pointerdown',
+		move: 'pointermove',
+		over: 'pointerover',
+		cancel: 'pointercancel',
+		out: 'pointerout',
+		leave: 'pointerleave',
+		enter:'pointerenter'
+	};
 
-    for(var eventName in pointer.EVENTS){
-        console.log(pointer.EVENTS[eventName]);
-        $div.addEventListener(pointer.EVENTS[eventName], function (event) {
+    for(var eventName in EVENTS){
+        console.log(EVENTS[eventName]);
+        $div.addEventListener(EVENTS[eventName], function (event) {
             var $eventElement = document.createElement('div');
             $eventElement.innerHTML = getTime()+': ' + event.type;
             $console.insertBefore($eventElement, $console.firstChild);
@@ -17,6 +26,6 @@
             + ((currentdate.getSeconds()<10) ? "0"+currentdate.getSeconds() : currentdate.getSeconds());
     }
 
-    function onChange() {
-        pointer.setMoveHoverState(document.getElementById('checkbox').checked);
+    function onChange() {		
+        $div.pointerTracker.setMoveHoverState(document.getElementById('checkbox').checked);
     }

--- a/example/index.js
+++ b/example/index.js
@@ -1,15 +1,15 @@
     var $div = document.querySelector('#pointer');
     var $console = document.querySelector('#console');
     var EVENTS = {
-		up: 'pointerup',
-		down: 'pointerdown',
-		move: 'pointermove',
-		over: 'pointerover',
-		cancel: 'pointercancel',
-		out: 'pointerout',
-		leave: 'pointerleave',
-		enter:'pointerenter'
-	};
+        up: 'pointerup',
+        down: 'pointerdown',
+        move: 'pointermove',
+        over: 'pointerover',
+        cancel: 'pointercancel',
+        out: 'pointerout',
+        leave: 'pointerleave',
+        enter: 'pointerenter'
+    };
 
     for(var eventName in EVENTS){
         console.log(EVENTS[eventName]);
@@ -26,6 +26,6 @@
             + ((currentdate.getSeconds()<10) ? "0"+currentdate.getSeconds() : currentdate.getSeconds());
     }
 
-    function onChange() {		
+    function onChange() {
         $div.pointerTracker.setMoveHoverState(document.getElementById('checkbox').checked);
     }

--- a/pointer.js
+++ b/pointer.js
@@ -297,12 +297,14 @@
     if (typeof exports !== 'undefined') {
         exports.module = PointerTracker;
     }
-	
-	var nativeAddEventListener = Element.prototype.addEventListener;
-	Element.prototype.addEventListener = function(evt){
-		if(evt.indexOf("pointer") === 0){ this.pointerTracker = new PointerTracker(this); }
-		return nativeAddEventListener.apply(this, arguments);
-	};
-	
+
+    var nativeAddEventListener = Element.prototype.addEventListener;
+    Element.prototype.addEventListener = function(evt){
+        if(evt.indexOf("pointer") === 0 && !this.pointerTracker){
+            this.pointerTracker = new PointerTracker(this); 
+        }
+        return nativeAddEventListener.apply(this, arguments);
+    };
+
     return PointerTracker;
 }));

--- a/pointer.js
+++ b/pointer.js
@@ -297,5 +297,12 @@
     if (typeof exports !== 'undefined') {
         exports.module = PointerTracker;
     }
+	
+	var nativeAddEventListener = Element.prototype.addEventListener;
+	Element.prototype.addEventListener = function(evt){
+		if(evt.indexOf("pointer") === 0){ this.pointerTracker = new PointerTracker(this); }
+		return nativeAddEventListener.apply(this, arguments);
+	};
+	
     return PointerTracker;
 }));


### PR DESCRIPTION
By overriding native addEventListener, we can automatically handle initialization of the PointerTracker for pointer events. The cost is minimal, the benefit for ease of use is real. Also, I added a pointerTracker property to the element so that you can add your own methods such as setMoveHoverState. The property name can be changed if you are concerned about possible future collisions.
